### PR TITLE
Simple freebsd extattr support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,16 +18,16 @@
 # Generic settings
 #
 CC              = gcc
-CFLAGS          = -g -Wall -pedantic -std=c99 -D_FILE_OFFSET_BITS=64 -O2
+LOCAL_CFLAGS    = $(CFLAGS) -g -Wall -pedantic -std=c99 -D_FILE_OFFSET_BITS=64 -O2
 LDFLAGS         =
 INCLUDES        =
 INSTALL         = install -c
 INSTALL_PROGRAM = ${INSTALL}
 INSTALL_DATA    = ${INSTALL} -m 644
-COMPILE         = $(CC) $(INCLUDES) $(CFLAGS)
-LINK            = $(CC) $(CFLAGS) $(LDFLAGS)
+COMPILE         = $(CC) $(INCLUDES) $(LOCAL_CFLAGS)
+LINK            = $(CC) $(LOCAL_CFLAGS) $(LDFLAGS)
 OBJECTS         = utils.o metastore.o metaentry.o
-HEADERS         = utils.h metastore.h metaentry.h
+HEADERS         = utils.h metastore.h metaentry.h freebsd.h
 
 DESTDIR        ?=
 prefix         	= /usr

--- a/README.freebsd
+++ b/README.freebsd
@@ -1,0 +1,10 @@
+Support for FreeBSD extended attributes
+=======================================
+
+The support for FreeBSD extended attributes is limited to one namespace at the
+moment, configurable at compile time by either:
+- Editing the header file "freebsd.h", altering the line #define NAMESPACE
+  value
+- Calling gmake with CFLAGS=-DNAMESPACE=value
+
+See extattr(9) for a list of acceptable values.

--- a/freebsd.h
+++ b/freebsd.h
@@ -1,0 +1,19 @@
+/* Headers to support extendeded attributes
+ *
+ * This is currently a dirty macro hack, and supports only a single namespace
+ * at a time, configurable only at compile time
+ *
+ */
+
+#ifndef NAMESPACE
+#define NAMESPACE   EXTATTR_NAMESPACE_USER
+#endif
+
+#include <sys/extattr.h>
+#include <errno.h>
+
+#define canonicalize_file_name(orig)                realpath(orig, NULL)
+#define listxattr(path, list, size)                 extattr_list_file(path, NAMESPACE, NULL, 0)
+#define lremovexattr(path, name)                    extattr_delete_link(path, NAMESPACE, name)
+#define getxattr(path, name, value, size)           extattr_get_file(path, NAMESPACE, name, value, 0)
+#define lsetxattr(path, name, value, size, options) extattr_set_link(path, NAMESPACE, name, value, size)

--- a/metaentry.c
+++ b/metaentry.c
@@ -25,13 +25,17 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+
 #ifdef __MACH__
 #include <sys/xattr.h>
 #include <errno.h>
 #define canonicalize_file_name(orig) realpath(orig, NULL)
+#elif defined __FreeBSD__
+#include "freebsd.h"
 #else
 #include <attr/xattr.h>
 #endif
+
 #include <limits.h>
 #include <dirent.h>
 #include <sys/mman.h>

--- a/metastore.c
+++ b/metastore.c
@@ -23,14 +23,18 @@
 #include <sys/stat.h>
 #include <getopt.h>
 #include <utime.h>
+
 #ifdef __MACH__
 #include <sys/xattr.h>
 #include <errno.h>
 #define lsetxattr(path, name, value, size, options)  setxattr(path, name, value, size, 0, options | XATTR_NOFOLLOW)
 #define lremovexattr(path, name) removexattr(path, name, XATTR_NOFOLLOW)
+#elif defined __FreeBSD__
+#include "freebsd.h"
 #else
 #include <attr/xattr.h>
 #endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>


### PR DESCRIPTION
I've added preprocessor macros to make sure that the function calls that deal with extended attributes doesn't fail. FreeBSD extended attributes are namespaced (see [extattr(9)](http://www.freebsd.org/cgi/man.cgi?query=extattr&apropos=0&sektion=9&manpath=FreeBSD+9.0-RELEASE&arch=default&format=html)), requiring some nontrivial rewriting to have be correctly handled by metastore, so this solution is very rudimentary. You have support for pulling ext attributes from a different namespace by supplying a compile time option, see README.freebsd.
